### PR TITLE
chore: add 'active' to color-picker of widgets

### DIFF
--- a/src/components/Configurator.vue
+++ b/src/components/Configurator.vue
@@ -61,7 +61,13 @@
               class="color-list__item"
               @click="setWidgetColor(s.widgetType, fillColor)"
             >
-              <div :style="{ background: fillColor }" class="bg-color" />
+              <div
+                :style="{ background: fillColor }"
+                class="bg-color"
+                :class="{
+                  active: fillColor === getWidgetColor(s.widgetType),
+                }"
+              />
             </li>
           </ul>
         </details>
@@ -203,6 +209,12 @@ function setWidgetColor(widgetType: WidgetType, fillColor: string) {
       },
     })
   }
+}
+
+function getWidgetColor(type: string) {
+  if (type === WidgetType.Tops || type === WidgetType.Clothes) {
+    return avatarOption.value.widgets[type]?.fillColor
+  } else return ''
 }
 </script>
 


### PR DESCRIPTION
I have found that there are no styles when color of tops or cloths is selected.

![Snipaste_2022-07-30_16-48-20](https://user-images.githubusercontent.com/35727398/181902962-c83e1826-3765-4850-9b37-ceaca746540c.jpg)

This PR is trying to fix it well 😆 