### PR TITLE
By modifying the Yarn registry to avoid certificate errors.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION

### Description
This commit updates the Yarn registry to resolve the certificate error encountered during the one-click deployment with Zeabur. The specific change is as follows:

- Updated the Yarn registry URL to a valid address to avoid errors caused by expired certificates.

### Related Issue
This fix addresses the following issue:
- **#25**: Certificate error during one-click deployment with Zeabur.

### Background
When using 1Panel's Docker to create the environment, the creation process was successful, but accessing it resulted in the following error:
- **HTTP ERROR 502**: The webpage is not working properly at 1*.1*.2*.41, currently unable to handle this request.

By updating the Yarn registry, the service is now available, ensuring a smooth deployment process.
